### PR TITLE
fix: preserve newlines in block content translation

### DIFF
--- a/src/api/utils/blockContentUtils/blockContentHtml.ts
+++ b/src/api/utils/blockContentUtils/blockContentHtml.ts
@@ -171,6 +171,11 @@ export const parseHtmlToSpans = (html: string): any[] => {
   const parser = new htmlparser2.Parser(
     {
       onopentag(name, attributes) {
+        // Special handling for <br> tags - convert to newline character
+        if (name === 'br') {
+          currentText += '\n';
+          return;
+        }
         // If we have accumulated text, create a span before changing marks
         if (currentText) {
           createSpan();
@@ -190,6 +195,10 @@ export const parseHtmlToSpans = (html: string): any[] => {
         currentText += text;
       },
       onclosetag(name) {
+        // Skip <br> tags as they're handled in onopentag
+        if (name === 'br') {
+          return;
+        }
         // Create a span with the accumulated text
         createSpan();
 


### PR DESCRIPTION
Handle <br> tags in HTML parsing to properly convert them to newline characters in translated block content. This ensures that formatting with newlines between spans is preserved during the translation process.

The issue was in the HTML parser not recognizing <br> tags and converting them to newline characters in the resulting spans. Added special handling in the parseHtmlToSpans function to properly process these tags.