### PR TITLE
feat: implement customizable translatable field keys

### DIFF
--- a/docs/CustomizableFieldKeys.md
+++ b/docs/CustomizableFieldKeys.md
@@ -1,0 +1,199 @@
+# Customizable Translatable Field Keys
+
+## Overview
+
+The Sanity Plugin Translate allows you to customize which fields are considered translatable in your Sanity documents. This feature gives you fine-grained control over the translation process by enabling you to:
+
+- Add custom field keys to the default list of translatable fields
+- Add custom array field keys to the default list of translatable array fields
+- Exclude specific default field keys from translation
+- Exclude specific default array field keys from translation
+
+This document explains how to configure and use customizable translatable field keys in your Sanity project.
+
+## Default Translatable Fields
+
+By default, the plugin translates the following field keys:
+
+### Default Translatable Field Keys
+```typescript
+[
+  'altText',
+  'label',
+  'text', // Used in Block Content structure within "children"
+  'title',
+  'seoTitle',
+  'description',
+  'subline',
+  'caption',
+  'emailSubject',
+  'isRequiredErrorMessage',
+  'errorTitle',
+  'actionButtonLabel',
+  'placeholder',
+  'featHeader',
+  'conHeader',
+  'proHeader',
+  'faqHeader',
+  'teaser',
+  'supportingText', // For Testimonial stats in Multi-card layout
+  'statNumber', // For Testimonial stats in Multi-card layout
+  { type: ['form', 'pageCategory', 'category'], key: 'name' },
+]
+```
+
+### Default Translatable Array Field Keys
+```typescript
+['keywords']
+```
+
+## Configuration Options
+
+The plugin offers four configuration options for customizing translatable field keys:
+
+### 1. `customTranslatableFieldKeys`
+
+An array of additional field keys to translate. Each item can be either:
+- A simple string (e.g., `'summary'`)
+- An object with `type` and `key` properties, where:
+  - `type` is an array of document types where this field should be translated
+  - `key` is the field name to translate
+
+### 2. `customTranslatableArrayFieldKeys`
+
+An array of additional array field keys to translate (e.g., `'tags'`).
+
+### 3. `excludeDefaultFieldKeys`
+
+An array of default field keys to exclude from translation (e.g., `'placeholder'`).
+
+### 4. `excludeDefaultArrayFieldKeys`
+
+An array of default array field keys to exclude from translation (e.g., `'keywords'`).
+
+## Usage Examples
+
+### Adding Custom Field Keys
+
+```typescript
+// In your API route that handles translation requests (e.g., pages/api/translate.ts)
+import { TranslationService } from 'sanity-plugin-translate/service';
+import { FieldKeyConfig } from 'sanity-plugin-translate/types';
+import { createClient } from '@sanity/client';
+
+// Create Sanity client
+const client = createClient({
+  projectId: process.env.SANITY_PROJECT_ID,
+  dataset: process.env.SANITY_DATASET,
+  token: process.env.SANITY_TOKEN,
+  useCdn: false,
+});
+
+// Define your custom field keys
+const fieldKeyConfig: FieldKeyConfig = {
+  customTranslatableFieldKeys: [
+    'summary',
+    'metaDescription',
+    { type: ['product'], key: 'specifications' }
+  ]
+};
+
+// Use the TranslationService with custom field keys
+const translationService = new TranslationService({
+  client,
+  deeplApiKey: process.env.DEEPL_API_KEY,
+  fieldKeyConfig,
+});
+```
+
+### Adding Custom Array Field Keys
+
+```typescript
+const fieldKeyConfig: FieldKeyConfig = {
+  customTranslatableArrayFieldKeys: ['tags', 'categories']
+};
+
+const translationService = new TranslationService({
+  client,
+  deeplApiKey: process.env.DEEPL_API_KEY,
+  fieldKeyConfig,
+});
+```
+
+### Excluding Default Field Keys
+
+```typescript
+const fieldKeyConfig: FieldKeyConfig = {
+  excludeDefaultFieldKeys: ['placeholder', 'supportingText']
+};
+
+const translationService = new TranslationService({
+  client,
+  deeplApiKey: process.env.DEEPL_API_KEY,
+  fieldKeyConfig,
+});
+```
+
+### Combining Multiple Options
+
+```typescript
+const fieldKeyConfig: FieldKeyConfig = {
+  customTranslatableFieldKeys: [
+    'summary',
+    { type: ['product'], key: 'specifications' }
+  ],
+  customTranslatableArrayFieldKeys: ['tags'],
+  excludeDefaultFieldKeys: ['placeholder'],
+  excludeDefaultArrayFieldKeys: []
+};
+
+const translationService = new TranslationService({
+  client,
+  deeplApiKey: process.env.DEEPL_API_KEY,
+  fieldKeyConfig,
+});
+```
+
+## How It Works
+
+When you configure custom field keys for the `TranslationService`:
+
+1. The service merges your custom field keys with the default ones (unless excluded)
+2. These merged keys are used internally by the `TranslationService`
+3. The service uses these keys to identify which fields should be translated during the document translation process
+
+The merging process preserves all default keys unless explicitly excluded, ensuring backward compatibility with existing projects.
+
+## Type-Specific Field Keys
+
+For fields that should only be translated in specific document types, use the object format:
+
+```javascript
+{ type: ['blogPost', 'page'], key: 'excerpt' }
+```
+
+This configuration will only translate the `excerpt` field in documents of type `blogPost` or `page`.
+
+## Best Practices
+
+1. **Start with defaults**: Begin with the default field keys and customize as needed.
+2. **Be selective**: Only translate fields that contain human-readable text.
+3. **Consider context**: Some fields might need special handling based on document type.
+4. **Test thoroughly**: Always test translations after customizing field keys.
+5. **Document your choices**: Keep a record of your customizations for future reference.
+
+## Technical Implementation
+
+The customizable field keys feature is implemented through:
+
+- `FieldKeyConfig` type exported from the plugin for type safety
+- `fieldKeyManager.ts` utility functions for merging and filtering keys
+- `TranslationService` constructor accepting a `fieldKeyConfig` parameter
+
+This implementation ensures backward compatibility while providing flexibility for project-specific requirements.
+
+## Important Note
+
+Customizable field keys should be configured when instantiating the `TranslationService` in your API route, not via plugin options in `sanity.config.ts`. This approach provides better separation of concerns and allows for different field key configurations in different API routes if needed.
+
+For more detailed information on integrating custom field keys into your project, see [Integrating Custom Field Keys](./IntegratingCustomFieldKeys.md).

--- a/docs/IntegratingCustomFieldKeys.md
+++ b/docs/IntegratingCustomFieldKeys.md
@@ -1,0 +1,277 @@
+# Implementing Customizable Field Keys
+
+This guide explains how to implement and use the customizable field keys feature in your Sanity project. It provides detailed instructions for configuring custom translatable fields in your API implementation.
+
+## Overview
+
+The customizable field keys feature allows you to specify which fields should be translated in your Sanity documents. This is implemented by configuring the `TranslationService` when you instantiate it in your API routes.
+
+## Implementation Approach
+
+The Sanity Translate plugin works as follows:
+
+1. **Document Actions**: The plugin provides document actions in the Sanity Studio UI
+2. **API Calls**: When a document action is triggered, it makes an API call to your project's API routes
+3. **Translation Service**: Your API routes instantiate the `TranslationService` to perform the actual translation
+
+Customizable field keys are configured at the third step, when you instantiate the `TranslationService` in your API routes.
+
+## Configuring Custom Field Keys
+
+### In Your API Route
+
+To use customizable field keys, configure them when instantiating the `TranslationService` in your API route:
+
+```typescript
+// Example: Next.js API route (app/api/translate/route.ts)
+import { TranslationService } from 'sanity-plugin-translate/service';
+import { translationApiRequestBody, FieldKeyConfig } from 'sanity-plugin-translate/types';
+import { sanityClient } from './your-sanity-client';
+
+export async function POST(req) {
+  const body = await req.json();
+  const { docId, type } = body;
+  
+  // Define your custom field keys
+  const fieldKeyConfig: FieldKeyConfig = {
+    customTranslatableFieldKeys: ['summary', 'metaDescription'],
+    customTranslatableArrayFieldKeys: ['tags'],
+    excludeDefaultFieldKeys: ['placeholder'],
+    excludeDefaultArrayFieldKeys: [],
+  };
+  
+  // Instantiate TranslationService with custom field keys
+  const translationService = new TranslationService({
+    client: sanityClient,
+    deeplApiKey: process.env.DEEPL_API_KEY,
+    fieldKeyConfig, // Pass your field key configuration
+  });
+  
+  // Use the service for translation
+  const result = await translationService.translateDocument({ data: { docId, type } });
+  
+  return new Response(JSON.stringify({ isTranslated: true }));
+}
+```
+
+### Using Constants for Type Safety
+
+For better type safety and reusability, you can define your custom field keys as constants:
+
+```typescript
+// fieldKeyConfig.ts
+import { FieldKeyConfig } from 'sanity-plugin-translate/types';
+
+/**
+ * Custom translatable field keys configuration
+ */
+export const FIELD_KEY_CONFIG: FieldKeyConfig = {
+  customTranslatableFieldKeys: [
+    'summary',
+    'metaDescription',
+    { type: ['product'], key: 'specifications' },
+  ],
+  customTranslatableArrayFieldKeys: ['tags', 'categories'],
+  excludeDefaultFieldKeys: ['placeholder'],
+  excludeDefaultArrayFieldKeys: [],
+};
+```
+
+Then import and use it in your API route:
+
+```typescript
+import { FIELD_KEY_CONFIG } from './fieldKeyConfig';
+
+// In your API route handler
+const translationService = new TranslationService({
+  client: sanityClient,
+  deeplApiKey: process.env.DEEPL_API_KEY,
+  fieldKeyConfig: FIELD_KEY_CONFIG,
+});
+```
+
+## How It Works
+
+### TranslationService Implementation
+
+The `TranslationService` has been updated to use the field key configuration for translation:
+
+```typescript
+// src/api/service/TranslationService.ts
+constructor(config: TranslationServiceOptions) {
+  this.client = config.client;
+  this.previewClient = config.previewClient;
+  this.deeplApiKey = config.deeplApiKey;
+
+  // Initialize field keys using configuration
+  this.translatableFieldKeys = getMergedTranslatableFieldKeys(config.fieldKeyConfig);
+  this.translatableArrayFieldKeys = getMergedTranslatableArrayFieldKeys(config.fieldKeyConfig);
+}
+```
+
+When you provide a `fieldKeyConfig` object, the service merges your custom keys with the default keys and applies any exclusions you've specified.
+
+### Field Key Manager
+
+The field key manager utilities handle merging custom keys with defaults and applying exclusions:
+
+```typescript
+// src/api/utils/fieldKeyManager.ts
+
+/**
+ * Merges custom translatable field keys with defaults, excluding specified keys
+ */
+export function getMergedTranslatableFieldKeys(
+  config?: FieldKeyConfig
+): (string | { type: string[]; key: string })[] {
+  if (!config) return DEFAULT_TRANSLATABLE_FIELD_KEYS;
+
+  const {
+    customTranslatableFieldKeys = [],
+    excludeDefaultFieldKeys = [],
+  } = config;
+
+  // Filter default keys based on exclusions
+  const filteredDefaults = DEFAULT_TRANSLATABLE_FIELD_KEYS.filter((key) => {
+    if (typeof key === 'string') {
+      return !excludeDefaultFieldKeys.includes(key);
+    }
+    return true; // Keep complex type keys by default
+  });
+
+  // Merge filtered defaults with custom keys
+  return [...filteredDefaults, ...customTranslatableFieldKeys];
+}
+```
+
+### FieldKeyConfig Type
+
+The `FieldKeyConfig` type defines the structure for custom field key configuration:
+
+```typescript
+export interface FieldKeyConfig {
+  customTranslatableFieldKeys?: (string | { type: string[]; key: string })[];
+  customTranslatableArrayFieldKeys?: string[];
+  excludeDefaultFieldKeys?: string[];
+  excludeDefaultArrayFieldKeys?: string[];
+}
+```
+
+This type is exported from the plugin and can be imported in your project for type safety.
+
+## Testing Your Implementation
+
+To verify that your implementation is working correctly:
+
+1. Configure your API route with custom field keys
+2. Create a document with fields matching your custom keys
+3. Use the "Translate Document" action from the document menu
+4. Verify that your custom fields are being translated
+5. Check that excluded fields are not translated
+
+## Example: Next.js API Route (App Router)
+
+Here's a complete example of a Next.js API route using the App Router:
+
+```typescript
+// app/api/translate/route.ts
+import { NextRequest } from 'next/server';
+import { TranslationService } from 'sanity-plugin-translate/service';
+import { translationApiRequestBody, FieldKeyConfig } from 'sanity-plugin-translate/types';
+import { sanityClient } from '../../lib/sanity';
+
+export const dynamic = 'force-dynamic';
+export const maxDuration = 300; // 5 minutes timeout for long translations
+
+export async function POST(req: NextRequest) {
+  // Validate webhook secret
+  const webhook_secret = req.headers.get('x-webhook-secret');
+  if (!webhook_secret || webhook_secret !== process.env.SANITY_TRANSLATE_WEBHOOK_SECRET) {
+    return new Response('Unauthorized', { status: 401 });
+  }
+  
+  // Parse and validate request body
+  const body = await req.json();
+  const parsedBody = translationApiRequestBody.safeParse(body);
+  if (!parsedBody.success) {
+    return new Response('Invalid request body', { status: 400 });
+  }
+  
+  // Define custom field keys
+  const fieldKeyConfig: FieldKeyConfig = {
+    customTranslatableFieldKeys: [
+      'summary',
+      'metaDescription',
+      { type: ['product'], key: 'specifications' }
+    ],
+    customTranslatableArrayFieldKeys: ['tags'],
+    excludeDefaultFieldKeys: ['placeholder'],
+    excludeDefaultArrayFieldKeys: [],
+  };
+  
+  try {
+    // Initialize TranslationService with custom field keys
+    const translationService = new TranslationService({
+      client: sanityClient,
+      deeplApiKey: process.env.DEEPL_API_KEY || '',
+      fieldKeyConfig, // Pass your field key configuration
+    });
+    
+    // Translate the document
+    const { isTranslated, translatedJsonData } = await translationService.translateDocument({
+      data: parsedBody.data,
+    });
+    
+    return new Response(
+      JSON.stringify({ isTranslated, translatedTexts: translatedJsonData }),
+      { status: 200, headers: { 'Content-Type': 'application/json' } }
+    );
+  } catch (error) {
+    console.error('Translation error:', error);
+    return new Response(
+      JSON.stringify({ error: 'Translation failed' }),
+      { status: 500, headers: { 'Content-Type': 'application/json' } }
+    );
+  }
+}
+```
+
+## Troubleshooting
+
+If your custom field keys are not being translated:
+
+1. **Check API Configuration**: Ensure your API route is correctly configuring the TranslationService
+2. **Verify Field Names**: Make sure the field names match exactly with your schema
+3. **Type-Specific Fields**: For type-specific fields, verify that the document type is correct
+4. **Console Logging**: Add console logs to check the merged field keys in your API route
+5. **API Response**: Check the API response for any error messages
+
+## Advanced Configuration Examples
+
+### Type-Specific Field Translation
+
+```typescript
+const fieldKeyConfig: FieldKeyConfig = {
+  customTranslatableFieldKeys: [
+    { type: ['product'], key: 'specifications' },
+    { type: ['article', 'blog'], key: 'excerpt' }
+  ]
+};
+```
+
+### Excluding Default Fields
+
+```typescript
+const fieldKeyConfig: FieldKeyConfig = {
+  excludeDefaultFieldKeys: ['placeholder', 'supportingText'],
+  excludeDefaultArrayFieldKeys: ['keywords']
+};
+```
+
+## Best Practices
+
+1. **Be Selective**: Only translate fields that contain human-readable text
+2. **Consider Document Types**: Use type-specific fields for targeted translation
+3. **Test Thoroughly**: Always test translations after customizing field keys
+4. **Document Your Choices**: Keep a record of your customizations for future reference
+5. **Centralize Configuration**: Define your field key configuration in a separate file for reuse

--- a/src/api/consts.ts
+++ b/src/api/consts.ts
@@ -1,0 +1,35 @@
+export const MEDIA_OBJECTS = [
+  'media',
+  'icon',
+  'mainImage',
+  'sanityIcon',
+  'productImage',
+];
+
+// Default translatable field keys (moved from TranslationService)
+export const DEFAULT_TRANSLATABLE_FIELD_KEYS = [
+  'altText',
+  'label',
+  'text', // Usually this is the field name that comes from the Block Content structure that is part from "children"
+  'title',
+  'seoTitle',
+  'description',
+  'subline',
+  'caption',
+  'emailSubject',
+  'isRequiredErrorMessage',
+  'errorTitle',
+  'actionButtonLabel',
+  'placeholder',
+  'featHeader',
+  'conHeader',
+  'proHeader',
+  'faqHeader',
+  'teaser',
+  'supportingText', // For the Testimonial stats (in Multi-card layout)
+  'statNumber', // For the Testimonial stats (in Multi-card layout)
+  { type: ['form', 'pageCategory', 'category'], key: 'name' },
+];
+
+// Default translatable array field keys (moved from TranslationService)
+export const DEFAULT_TRANSLATABLE_ARRAY_FIELD_KEYS = ['keywords'];

--- a/src/api/utils/fieldKeyManager.ts
+++ b/src/api/utils/fieldKeyManager.ts
@@ -1,0 +1,61 @@
+import { FieldKeyConfig } from '../../types/translationApi';
+import {
+  DEFAULT_TRANSLATABLE_ARRAY_FIELD_KEYS,
+  DEFAULT_TRANSLATABLE_FIELD_KEYS,
+} from '../consts';
+
+/**
+ * Merges custom translatable field keys with defaults, excluding specified keys
+ */
+export function getMergedTranslatableFieldKeys(
+  config?: FieldKeyConfig,
+): (string | { type: string[]; key: string })[] {
+  let mergedKeys = [...DEFAULT_TRANSLATABLE_FIELD_KEYS];
+
+  // Add custom field keys if provided
+  if (config?.customTranslatableFieldKeys) {
+    mergedKeys = [...mergedKeys, ...config.customTranslatableFieldKeys];
+  }
+
+  // Remove excluded default keys if specified
+  if (
+    config?.excludeDefaultFieldKeys &&
+    config.excludeDefaultFieldKeys.length > 0
+  ) {
+    mergedKeys = mergedKeys.filter((key) => {
+      if (typeof key === 'string') {
+        return !config.excludeDefaultFieldKeys!.includes(key);
+      }
+      // For object keys, check if the key property should be excluded
+      return !config.excludeDefaultFieldKeys!.includes(key.key);
+    });
+  }
+
+  return mergedKeys;
+}
+
+/**
+ * Merges custom translatable array field keys with defaults, excluding specified keys
+ */
+export function getMergedTranslatableArrayFieldKeys(
+  config?: FieldKeyConfig,
+): string[] {
+  let mergedKeys = [...DEFAULT_TRANSLATABLE_ARRAY_FIELD_KEYS];
+
+  // Add custom array field keys if provided
+  if (config?.customTranslatableArrayFieldKeys) {
+    mergedKeys = [...mergedKeys, ...config.customTranslatableArrayFieldKeys];
+  }
+
+  // Remove excluded default keys if specified
+  if (
+    config?.excludeDefaultArrayFieldKeys &&
+    config.excludeDefaultArrayFieldKeys.length > 0
+  ) {
+    mergedKeys = mergedKeys.filter(
+      (key) => !config.excludeDefaultArrayFieldKeys!.includes(key),
+    );
+  }
+
+  return mergedKeys;
+}

--- a/src/exports/types/index.ts
+++ b/src/exports/types/index.ts
@@ -1,1 +1,4 @@
-export { translationApiRequestBody } from '../../types/translationApi';
+export {
+  type FieldKeyConfig,
+  translationApiRequestBody,
+} from '../../types/translationApi';

--- a/src/types/translationApi.ts
+++ b/src/types/translationApi.ts
@@ -1,10 +1,19 @@
 import { SanityClient } from 'sanity';
 import { z } from 'zod';
 
+// Field key configuration interface
+export interface FieldKeyConfig {
+  customTranslatableFieldKeys?: (string | { type: string[]; key: string })[];
+  customTranslatableArrayFieldKeys?: string[];
+  excludeDefaultFieldKeys?: string[];
+  excludeDefaultArrayFieldKeys?: string[];
+}
+
 export interface TranslationServiceOptions {
   client: SanityClient;
   previewClient?: SanityClient;
   deeplApiKey: string;
+  fieldKeyConfig?: FieldKeyConfig;
 }
 
 export const documentComparisonMetadata = z.object({


### PR DESCRIPTION
- Add support for configuring custom field keys via TranslationService
- Remove field key configuration from plugin options
- Update documentation with API route implementation examples
- Add field key manager utilities for merging and exclusion
- Enhance default field keys with supportingText and statNumber
- Fix TranslationService to properly commit translated content